### PR TITLE
Fix vault update

### DIFF
--- a/cabinet/vault.py
+++ b/cabinet/vault.py
@@ -81,7 +81,7 @@ class Vault(object):
         :param new_item: the new item's contents
         :type new_item: dict
         """
-        item = self.get(name)
+        item = self.get(name, full=True)
 
         if item is None:
             raise Exception("The specified item does not exist.")


### PR DESCRIPTION
Fix the vault update. Recover the full item before trying to update
it. This allows to recover the hashname of the item as well. The
hashname is requried for updating the item, as it's the file name
where the data is stored.